### PR TITLE
feat: 🎸 add endpoint for auditors to verify all legs in a tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.3.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.1.0",
     "@polymeshassociation/local-signing-manager": "^3.1.0",
-    "@polymeshassociation/polymesh-private-sdk": "^1.0.0-alpha.8",
+    "@polymeshassociation/polymesh-private-sdk": "1.0.0-alpha.10",
     "@polymeshassociation/signing-manager-types": "^3.1.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/confidential-proofs/confidential-proofs.controller.spec.ts
+++ b/src/confidential-proofs/confidential-proofs.controller.spec.ts
@@ -191,4 +191,20 @@ describe('ConfidentialProofsController', () => {
       expect(result).toEqual(txResult);
     });
   });
+
+  describe('auditorVerifyTransaction', () => {
+    it('should call the service and return the results', async () => {
+      const input = {
+        auditorKey: 'SOME_PUBLIC_KEY',
+      };
+      const id = new BigNumber(1);
+
+      when(mockConfidentialTransactionsService.verifyTransactionAsAuditor)
+        .calledWith(id, input)
+        .mockResolvedValue([]);
+
+      const result = await controller.auditorVerifyTransaction({ id }, input);
+      expect(result).toEqual({ verifications: [] });
+    });
+  });
 });

--- a/src/confidential-proofs/confidential-proofs.service.ts
+++ b/src/confidential-proofs/confidential-proofs.service.ts
@@ -116,11 +116,13 @@ export class ConfidentialProofsService {
       `verifySenderProofAsAuditor - Verifying sender proof ${params.senderProof} for account ${confidentialAccount}`
     );
 
-    return this.requestProofServer(
+    const response = await this.requestProofServer<SenderProofVerificationResponseModel>(
       `accounts/${confidentialAccount}/auditor_verify`,
       'POST',
       params
     );
+
+    return new SenderProofVerificationResponseModel(response);
   }
 
   /**
@@ -134,11 +136,13 @@ export class ConfidentialProofsService {
       `verifySenderProofAsReceiver - Verifying sender proof ${params.senderProof} for account ${confidentialAccount}`
     );
 
-    return this.requestProofServer(
+    const response = await this.requestProofServer<SenderProofVerificationResponseModel>(
       `accounts/${confidentialAccount}/receiver_verify`,
       'POST',
       params
     );
+
+    return new SenderProofVerificationResponseModel(response);
   }
 
   /**
@@ -152,11 +156,13 @@ export class ConfidentialProofsService {
       `decryptBalance - Decrypting balance ${params.encryptedValue} for account ${confidentialAccount}`
     );
 
-    return this.requestProofServer<DecryptedBalanceModel>(
+    const response = await this.requestProofServer<DecryptedBalanceModel>(
       `accounts/${confidentialAccount}/decrypt`,
       'POST',
       params
     );
+
+    return new DecryptedBalanceModel(response);
   }
 
   /**

--- a/src/confidential-proofs/dto/auditor-verify-transaction.dto.ts
+++ b/src/confidential-proofs/dto/auditor-verify-transaction.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class AuditorVerifyTransactionDto {
+  @ApiProperty({
+    description:
+      'The public key of the auditor to verify with. Any leg with a provided sender proof involving this auditor will be verified. The corresponding private must be present in the proof server',
+  })
+  @IsString()
+  readonly auditorKey: string;
+}

--- a/src/confidential-proofs/models/auditor-verify-proof.model.ts
+++ b/src/confidential-proofs/models/auditor-verify-proof.model.ts
@@ -1,0 +1,64 @@
+/* istanbul ignore file */
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-private-sdk';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+
+export class AuditorVerifyProofModel {
+  @ApiProperty({
+    description: 'The leg ID for which this response relates to',
+    type: 'string',
+    example: '1',
+  })
+  @FromBigNumber()
+  readonly legId: BigNumber;
+
+  @ApiProperty({
+    description: 'The asset ID for which this response relates to',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  readonly assetId: string;
+
+  @ApiProperty({
+    description:
+      'Wether the sender has provided proof for the leg. If a proof has yet to be provided, then the amount being transferred has yet to be determined',
+  })
+  readonly isProved: boolean;
+
+  @ApiProperty({
+    description:
+      'Wether is specified public key is an auditor for the related portion of the transaction. If not, then the given auditor is unable to decrypt the amount',
+  })
+  readonly isAuditor: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'The amount of the asset being transferred in this leg. Will only be present if sender has already submitted the proof and the provided auditor was specified',
+    type: 'string',
+    nullable: true,
+    example: '100',
+  })
+  @FromBigNumber()
+  readonly amount: BigNumber | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Wether the proof server determined to sender proof to be valid or not. Will only be present if the sender has already submitted the proof and the provided auditor was specified',
+    type: 'string',
+    nullable: true,
+  })
+  readonly isValid: boolean | null;
+
+  @ApiPropertyOptional({
+    description: 'The error message provided by the proof server, if one was returned',
+    type: 'string',
+    nullable: true,
+  })
+  readonly errMsg: string | null;
+
+  constructor(model: AuditorVerifyProofModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/confidential-proofs/models/auditor-verify-transaction.model.ts
+++ b/src/confidential-proofs/models/auditor-verify-transaction.model.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+import { AuditorVerifyProofModel } from '~/confidential-proofs/models/auditor-verify-proof.model';
+
+export class AuditorVerifyTransactionModel {
+  @ApiProperty({
+    description: 'The verification status of each leg and asset',
+    isArray: true,
+    type: AuditorVerifyProofModel,
+  })
+  @Type(() => AuditorVerifyProofModel)
+  readonly verifications: AuditorVerifyProofModel[];
+
+  constructor(model: AuditorVerifyTransactionModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/confidential-transactions/confidential-venues.controller.ts
+++ b/src/confidential-transactions/confidential-venues.controller.ts
@@ -71,7 +71,7 @@ export class ConfidentialVenuesController {
 
   @ApiTags('confidential-transactions')
   @ApiOperation({
-    summary: 'Create a new Confidential Transactions',
+    summary: 'Create a new Confidential Transaction',
   })
   @ApiParam({
     name: 'id',

--- a/src/confidential-transactions/dto/confidential-leg-amount.dto.ts
+++ b/src/confidential-transactions/dto/confidential-leg-amount.dto.ts
@@ -21,6 +21,6 @@ export class ConfidentialLegAmountDto {
     example: '1000',
   })
   @ToBigNumber()
-  @IsBigNumber({ min: 1 })
+  @IsBigNumber({ min: 0 })
   readonly amount: BigNumber;
 }

--- a/src/confidential-transactions/dto/confidential-transaction-leg.dto.ts
+++ b/src/confidential-transactions/dto/confidential-transaction-leg.dto.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 
 import { IsConfidentialAssetId, IsDid } from '~/common/decorators/validation';
 
@@ -34,7 +34,7 @@ export class ConfidentialTransactionLegDto {
   @IsString()
   readonly receiver: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The Confidential Accounts of the auditors of the transaction leg',
     type: 'string',
     isArray: true,
@@ -42,15 +42,16 @@ export class ConfidentialTransactionLegDto {
   })
   @IsArray()
   @IsString({ each: true })
-  readonly auditors: string[];
+  readonly auditors: string[] = [];
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The DID of mediators of the transaction leg',
     type: 'string',
     isArray: true,
     example: ['0x0600000000000000000000000000000000000000000000000000000000000000'],
   })
+  @IsOptional()
   @IsArray()
   @IsDid({ each: true })
-  readonly mediators: string[];
+  readonly mediators: string[] = [];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,10 +1990,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.2.0"
 
-"@polymeshassociation/polymesh-private-sdk@^1.0.0-alpha.8":
-  version "1.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-private-sdk/-/polymesh-private-sdk-1.0.0-alpha.8.tgz#9b8e6a809ac29d3ba4fa186f4e89818f517ad95e"
-  integrity sha512-cYMkD1eA9AXfUX0O1Tai7jH8v/NxwDr5AGkDtt8kDn2zmTDLPGbeTzOUgeJLxf7SIil9Hku9zI3ehG/jll7jag==
+"@polymeshassociation/polymesh-private-sdk@1.0.0-alpha.10":
+  version "1.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-private-sdk/-/polymesh-private-sdk-1.0.0-alpha.10.tgz#4c94153f9eb66375fb621c0a22dc1635f0e9978f"
+  integrity sha512-dwwuflkSiI6Huv2FxoSN1eijreqx6Dk2Gal4bTY5Igsu3j1hxqWOJ25nnAaFkfEI3lh/gzkONRMYDUFYcR1aLg==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "10.9.1"


### PR DESCRIPTION
### JIRA Link 

✅ Closes: [DA-1120](https://polymesh.atlassian.net/browse/DA-1120)

### Changelog / Description 

add POST /confidential-transactions/:id/auditor-verify which allows auditors to verify all legs in a transaction where they are involved as auditors and the sender has provided proof


### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-1120]: https://polymesh.atlassian.net/browse/DA-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ