### PR TITLE
feat: 🎸 Add `GET confidential-transactions/:id/created-at`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.3.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.1.0",
     "@polymeshassociation/local-signing-manager": "^3.1.0",
-    "@polymeshassociation/polymesh-private-sdk": "1.0.0-alpha.11",
+    "@polymeshassociation/polymesh-private-sdk": "1.0.0-alpha.12",
     "@polymeshassociation/signing-manager-types": "^3.1.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -375,7 +375,7 @@ describe('ConfidentialAssetsService', () => {
   });
 
   describe('createdAt', () => {
-    it('should return creation event details for a Confidential Account', async () => {
+    it('should return creation event details for a Confidential Asset', async () => {
       const mockResult = {
         blockNumber: new BigNumber('2719172'),
         blockHash: 'someHash',
@@ -395,7 +395,7 @@ describe('ConfidentialAssetsService', () => {
   });
 
   describe('transactionHistory', () => {
-    it('should return creation event details for a Confidential Account', async () => {
+    it('should return transaction history of a Confidential Asset', async () => {
       const mockResult = {
         data: [
           {

--- a/src/confidential-transactions/confidential-transactions.controller.spec.ts
+++ b/src/confidential-transactions/confidential-transactions.controller.spec.ts
@@ -48,13 +48,9 @@ describe('ConfidentialTransactionsController', () => {
     it('should return the details of Confidential Transaction', async () => {
       const details = {
         status: ConfidentialTransactionStatus.Pending,
-        createdAt: new Date('2023/02/01'),
+        createdAt: new BigNumber(100000),
         memo: 'SOME_MEMO',
         venueId: new BigNumber(1),
-      };
-      const mockDetails = {
-        ...details,
-        createdAt: new BigNumber(details.createdAt.getTime()),
       };
       const mockLeg = {
         id: new BigNumber(0),
@@ -70,7 +66,7 @@ describe('ConfidentialTransactionsController', () => {
       };
       const mockConfidentialTransaction = createMockConfidentialTransaction();
 
-      mockConfidentialTransaction.details.mockResolvedValue(mockDetails);
+      mockConfidentialTransaction.details.mockResolvedValue(details);
       mockConfidentialTransaction.getLegs.mockResolvedValue([mockLeg]);
 
       mockConfidentialTransactionsService.findOne.mockResolvedValue(mockConfidentialTransaction);

--- a/src/confidential-transactions/confidential-transactions.service.spec.ts
+++ b/src/confidential-transactions/confidential-transactions.service.spec.ts
@@ -283,7 +283,7 @@ describe('ConfidentialTransactionsService', () => {
       mockConfidentialTransactionModel = new ConfidentialTransactionModel({
         id: new BigNumber(1),
         venueId: new BigNumber(1),
-        createdAt: new Date('2024/01/01'),
+        createdAt: new BigNumber(100000),
         status: ConfidentialTransactionStatus.Pending,
         memo: 'Some transfer memo',
         legs: [
@@ -794,6 +794,26 @@ describe('ConfidentialTransactionsService', () => {
           auditorKey,
         })
       ).rejects.toThrow(AppInternalError);
+    });
+  });
+
+  describe('createdAt', () => {
+    it('should return creation event details for a Confidential Transaction', async () => {
+      const mockResult = {
+        blockHash: 'someHash',
+        eventIndex: new BigNumber(1),
+        blockNumber: new BigNumber('2719172'),
+        blockDate: new Date('2023-06-26T01:47:45.000Z'),
+      };
+      const transaction = createMockConfidentialTransaction();
+
+      transaction.createdAt.mockResolvedValue(mockResult);
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(transaction);
+
+      const result = await service.createdAt(new BigNumber(10));
+
+      expect(result).toEqual(mockResult);
     });
   });
 });

--- a/src/confidential-transactions/confidential-transactions.service.ts
+++ b/src/confidential-transactions/confidential-transactions.service.ts
@@ -4,6 +4,7 @@ import {
   ConfidentialAffirmParty,
   ConfidentialTransaction,
   ConfidentialVenue,
+  EventIdentifier,
   Identity,
 } from '@polymeshassociation/polymesh-sdk/types';
 
@@ -347,5 +348,11 @@ export class ConfidentialTransactionsService {
     });
 
     return response.sort((a, b) => a.legId.minus(b.legId).toNumber());
+  }
+
+  public async createdAt(id: BigNumber): Promise<EventIdentifier | null> {
+    const transaction = await this.findOne(id);
+
+    return transaction.createdAt();
   }
 }

--- a/src/confidential-transactions/confidential-transactions.util.ts
+++ b/src/confidential-transactions/confidential-transactions.util.ts
@@ -38,7 +38,7 @@ export async function createConfidentialTransactionModel(
     venueId,
     memo,
     status,
-    createdAt: new Date(createdAt.toNumber()),
+    createdAt,
     legs,
   });
 }

--- a/src/confidential-transactions/models/confidential-transaction.model.ts
+++ b/src/confidential-transactions/models/confidential-transaction.model.ts
@@ -26,11 +26,12 @@ export class ConfidentialTransactionModel {
   readonly venueId: BigNumber;
 
   @ApiProperty({
-    description: 'Date when the Confidential Transaction was created',
+    description: 'Block number at which the Confidential Transaction was created',
     type: 'string',
-    example: new Date('10/14/1987').toISOString(),
+    example: '100000',
   })
-  readonly createdAt: Date;
+  @FromBigNumber()
+  readonly createdAt: BigNumber;
 
   @ApiProperty({
     description: 'The current status of the Confidential Transaction',

--- a/src/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller.spec.ts
+++ b/src/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller.spec.ts
@@ -1,0 +1,91 @@
+import { DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
+import { ConfidentialTransactionDirectionEnum } from '~/common/types';
+import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
+import { ConfidentialAccountsMiddlewareController } from '~/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller';
+import { createMockConfidentialAsset, createMockConfidentialTransaction } from '~/test-utils/mocks';
+import { mockConfidentialAccountsServiceProvider } from '~/test-utils/service-mocks';
+
+describe('ConfidentialAccountsMiddlewareController', () => {
+  let controller: ConfidentialAccountsMiddlewareController;
+  let mockConfidentialAccountsService: DeepMocked<ConfidentialAccountsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfidentialAccountsMiddlewareController],
+      providers: [mockConfidentialAccountsServiceProvider],
+    }).compile();
+
+    mockConfidentialAccountsService = module.get<typeof mockConfidentialAccountsService>(
+      ConfidentialAccountsService
+    );
+
+    controller = module.get<ConfidentialAccountsMiddlewareController>(
+      ConfidentialAccountsMiddlewareController
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getHeldAssets', () => {
+    it('should return a paginated list of held Confidential Assets', async () => {
+      const mockAssets = {
+        data: [
+          createMockConfidentialAsset({ id: 'SOME_ASSET_ID_1' }),
+          createMockConfidentialAsset({ id: 'SOME_ASSET_ID_2' }),
+        ],
+        next: new BigNumber(2),
+        count: new BigNumber(2),
+      };
+
+      mockConfidentialAccountsService.findHeldAssets.mockResolvedValue(mockAssets);
+
+      const result = await controller.getHeldAssets(
+        { confidentialAccount: 'SOME_PUBLIC_KEY' },
+        { start: new BigNumber(0), size: new BigNumber(2) }
+      );
+
+      expect(result).toEqual(
+        new PaginatedResultsModel({
+          results: expect.arrayContaining([{ id: 'SOME_ASSET_ID_2' }, { id: 'SOME_ASSET_ID_2' }]),
+          total: new BigNumber(mockAssets.count),
+          next: mockAssets.next,
+        })
+      );
+    });
+  });
+
+  describe('getAssociatedTransactions', () => {
+    it('should return the transactions associated with a given Confidential Account', async () => {
+      const mockResult = {
+        data: [createMockConfidentialTransaction()],
+        next: new BigNumber(1),
+        count: new BigNumber(1),
+      };
+
+      mockConfidentialAccountsService.getAssociatedTransactions.mockResolvedValue(mockResult);
+
+      const result = await controller.getAssociatedTransactions(
+        { confidentialAccount: 'SOME_PUBLIC_KEY' },
+        {
+          size: new BigNumber(1),
+          start: new BigNumber(0),
+          direction: ConfidentialTransactionDirectionEnum.All,
+        }
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          results: mockResult.data,
+          next: mockResult.next,
+          total: mockResult.count,
+        })
+      );
+    });
+  });
+});

--- a/src/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller.ts
+++ b/src/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller.ts
@@ -1,0 +1,111 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ConfidentialTransaction } from '@polymeshassociation/polymesh-private-sdk/internal';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { ApiArrayResponse } from '~/common/decorators/swagger';
+import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
+import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
+import { ConfidentialTransactionDirectionEnum } from '~/common/types';
+import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
+import { ConfidentialAccountParamsDto } from '~/confidential-accounts/dto/confidential-account-params.dto';
+import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
+import { ConfidentialAssetModel } from '~/confidential-assets/models/confidential-asset.model';
+import { ConfidentialAccountTransactionsDto } from '~/middleware/dto/confidential-account-transaction-params.dto';
+
+@ApiTags('confidential-accounts')
+@Controller()
+export class ConfidentialAccountsMiddlewareController {
+  constructor(
+    private readonly confidentialAssetsService: ConfidentialAssetsService,
+    private readonly confidentialAccountsService: ConfidentialAccountsService
+  ) {}
+
+  @ApiTags('confidential-assets')
+  @ApiOperation({
+    summary: 'Fetch all Confidential Assets held by a Confidential Account',
+    description:
+      'This endpoint returns a list of all Confidential Assets which were held at one point by the given Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiArrayResponse(ConfidentialAssetModel, {
+    description: 'List of all the held Confidential Assets',
+    paginated: true,
+  })
+  @Get('confidential-accounts/:confidentialAccount/held-confidential-assets')
+  public async getHeldAssets(
+    @Param() { confidentialAccount }: ConfidentialAccountParamsDto,
+    @Query() { size, start }: PaginatedParamsDto
+  ): Promise<PaginatedResultsModel<ConfidentialAssetModel>> {
+    const { data, count, next } = await this.confidentialAccountsService.findHeldAssets(
+      confidentialAccount,
+      size,
+      new BigNumber(start || 0)
+    );
+
+    return new PaginatedResultsModel({
+      results: data.map(({ id }) => new ConfidentialAssetModel({ id })),
+      total: count,
+      next,
+    });
+  }
+
+  @ApiTags('confidential-transactions')
+  @ApiOperation({
+    summary: 'Get the transactions associated to a Confidential Account',
+    description:
+      'This endpoint provides a list of transactions associated to a Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiQuery({
+    name: 'direction',
+    description: 'The direction of the transactions with respect to the given Confidential Account',
+    type: 'string',
+    enum: ConfidentialTransactionDirectionEnum,
+    example: ConfidentialTransactionDirectionEnum.All,
+  })
+  @ApiQuery({
+    name: 'size',
+    description: 'The number of transactions to be fetched',
+    type: 'string',
+    required: false,
+    example: '10',
+  })
+  @ApiQuery({
+    name: 'start',
+    description: 'Start key from which transactions are to be fetched',
+    type: 'string',
+    required: false,
+  })
+  @ApiNotFoundResponse({
+    description: 'The confidential account was not found',
+  })
+  @Get('confidential-accounts/:confidentialAccount/associated-transactions')
+  async getAssociatedTransactions(
+    @Param() { confidentialAccount }: ConfidentialAccountParamsDto,
+    @Query() { size, start, direction }: ConfidentialAccountTransactionsDto
+  ): Promise<PaginatedResultsModel<ConfidentialTransaction>> {
+    const { data, count, next } = await this.confidentialAccountsService.getAssociatedTransactions(
+      confidentialAccount,
+      direction,
+      size,
+      new BigNumber(start || 0)
+    );
+
+    return new PaginatedResultsModel({
+      results: data,
+      total: count,
+      next,
+    });
+  }
+}

--- a/src/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller.ts
+++ b/src/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller.ts
@@ -9,17 +9,13 @@ import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ConfidentialTransactionDirectionEnum } from '~/common/types';
 import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
 import { ConfidentialAccountParamsDto } from '~/confidential-accounts/dto/confidential-account-params.dto';
-import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { ConfidentialAssetModel } from '~/confidential-assets/models/confidential-asset.model';
 import { ConfidentialAccountTransactionsDto } from '~/middleware/dto/confidential-account-transaction-params.dto';
 
 @ApiTags('confidential-accounts')
 @Controller()
 export class ConfidentialAccountsMiddlewareController {
-  constructor(
-    private readonly confidentialAssetsService: ConfidentialAssetsService,
-    private readonly confidentialAccountsService: ConfidentialAccountsService
-  ) {}
+  constructor(private readonly confidentialAccountsService: ConfidentialAccountsService) {}
 
   @ApiTags('confidential-assets')
   @ApiOperation({

--- a/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.spec.ts
+++ b/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.spec.ts
@@ -5,34 +5,23 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { EventIdEnum } from '@polymeshassociation/polymesh-sdk/types';
 
 import { EventIdentifierModel } from '~/common/models/event-identifier.model';
-import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
-import { ConfidentialTransactionDirectionEnum } from '~/common/types';
-import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { ConfidentialAssetsMiddlewareController } from '~/middleware/confidential-assets-middleware/confidential-assets-middleware.controller';
-import { createMockConfidentialAsset, createMockConfidentialTransaction } from '~/test-utils/mocks';
-import {
-  mockConfidentialAccountsServiceProvider,
-  mockConfidentialAssetsServiceProvider,
-} from '~/test-utils/service-mocks';
+import { mockConfidentialAssetsServiceProvider } from '~/test-utils/service-mocks';
 
 describe('ConfidentialAssetsMiddlewareController', () => {
   let controller: ConfidentialAssetsMiddlewareController;
   let mockConfidentialAssetsService: DeepMocked<ConfidentialAssetsService>;
-  let mockConfidentialAccountsService: DeepMocked<ConfidentialAccountsService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ConfidentialAssetsMiddlewareController],
-      providers: [mockConfidentialAssetsServiceProvider, mockConfidentialAccountsServiceProvider],
+      providers: [mockConfidentialAssetsServiceProvider],
     }).compile();
 
     mockConfidentialAssetsService =
       module.get<typeof mockConfidentialAssetsService>(ConfidentialAssetsService);
 
-    mockConfidentialAccountsService = module.get<typeof mockConfidentialAccountsService>(
-      ConfidentialAccountsService
-    );
     controller = module.get<ConfidentialAssetsMiddlewareController>(
       ConfidentialAssetsMiddlewareController
     );
@@ -68,34 +57,6 @@ describe('ConfidentialAssetsMiddlewareController', () => {
     });
   });
 
-  describe('getHeldAssets', () => {
-    it('should return a paginated list of held Confidential Assets', async () => {
-      const mockAssets = {
-        data: [
-          createMockConfidentialAsset({ id: 'SOME_ASSET_ID_1' }),
-          createMockConfidentialAsset({ id: 'SOME_ASSET_ID_2' }),
-        ],
-        next: new BigNumber(2),
-        count: new BigNumber(2),
-      };
-
-      mockConfidentialAccountsService.findHeldAssets.mockResolvedValue(mockAssets);
-
-      const result = await controller.getHeldAssets(
-        { confidentialAccount: 'SOME_PUBLIC_KEY' },
-        { start: new BigNumber(0), size: new BigNumber(2) }
-      );
-
-      expect(result).toEqual(
-        new PaginatedResultsModel({
-          results: expect.arrayContaining([{ id: 'SOME_ASSET_ID_2' }, { id: 'SOME_ASSET_ID_2' }]),
-          total: new BigNumber(mockAssets.count),
-          next: mockAssets.next,
-        })
-      );
-    });
-  });
-
   describe('getTransactionHistory', () => {
     it('should return the transaction history', async () => {
       const mockResult = {
@@ -122,35 +83,6 @@ describe('ConfidentialAssetsMiddlewareController', () => {
       const result = await controller.getTransactionHistory(
         { confidentialAssetId: 'SOME_ASSET_ID' },
         { size: new BigNumber(10) }
-      );
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          results: mockResult.data,
-          next: mockResult.next,
-          total: mockResult.count,
-        })
-      );
-    });
-  });
-
-  describe('getAssociatedTransactions', () => {
-    it('should return the transactions associated with a given Confidential Account', async () => {
-      const mockResult = {
-        data: [createMockConfidentialTransaction()],
-        next: new BigNumber(1),
-        count: new BigNumber(1),
-      };
-
-      mockConfidentialAccountsService.getAssociatedTransactions.mockResolvedValue(mockResult);
-
-      const result = await controller.getAssociatedTransactions(
-        { confidentialAccount: 'SOME_PUBLIC_KEY' },
-        {
-          size: new BigNumber(1),
-          start: new BigNumber(0),
-          direction: ConfidentialTransactionDirectionEnum.All,
-        }
       );
 
       expect(result).toEqual(

--- a/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.ts
+++ b/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.ts
@@ -7,22 +7,17 @@ import {
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
-import { ConfidentialTransaction } from '@polymeshassociation/polymesh-private-sdk/internal';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 
-import { ApiArrayResponse } from '~/common/decorators/swagger';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
 import { EventIdentifierModel } from '~/common/models/event-identifier.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
-import { ConfidentialTransactionDirectionEnum } from '~/common/types';
 import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
-import { ConfidentialAccountParamsDto } from '~/confidential-accounts/dto/confidential-account-params.dto';
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { ConfidentialAssetIdParamsDto } from '~/confidential-assets/dto/confidential-asset-id-params.dto';
-import { ConfidentialAssetModel } from '~/confidential-assets/models/confidential-asset.model';
 import { ConfidentialAssetTransactionModel } from '~/confidential-assets/models/confidential-asset-transaction.model';
-import { ConfidentialAccountTransactionsDto } from '~/middleware/dto/confidential-account-transaction-params.dto';
 
+@ApiTags('confidential-assets')
 @Controller()
 export class ConfidentialAssetsMiddlewareController {
   constructor(
@@ -30,7 +25,6 @@ export class ConfidentialAssetsMiddlewareController {
     private readonly confidentialAccountsService: ConfidentialAccountsService
   ) {}
 
-  @ApiTags('confidential-assets')
   @ApiOperation({
     summary: 'Get creation event data for a Confidential Asset',
     description:
@@ -62,40 +56,6 @@ export class ConfidentialAssetsMiddlewareController {
     }
 
     return new EventIdentifierModel(result);
-  }
-
-  @ApiTags('confidential-accounts', 'confidential-assets')
-  @ApiOperation({
-    summary: 'Fetch all Confidential Assets held by a Confidential Account',
-    description:
-      'This endpoint returns a list of all Confidential Assets which were held at one point by the given Confidential Account',
-  })
-  @ApiParam({
-    name: 'confidentialAccount',
-    description: 'The public key of the Confidential Account',
-    type: 'string',
-    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
-  })
-  @ApiArrayResponse(ConfidentialAssetModel, {
-    description: 'List of all the held Confidential Assets',
-    paginated: true,
-  })
-  @Get('confidential-accounts/:confidentialAccount/held-confidential-assets')
-  public async getHeldAssets(
-    @Param() { confidentialAccount }: ConfidentialAccountParamsDto,
-    @Query() { size, start }: PaginatedParamsDto
-  ): Promise<PaginatedResultsModel<ConfidentialAssetModel>> {
-    const { data, count, next } = await this.confidentialAccountsService.findHeldAssets(
-      confidentialAccount,
-      size,
-      new BigNumber(start || 0)
-    );
-
-    return new PaginatedResultsModel({
-      results: data.map(({ id }) => new ConfidentialAssetModel({ id })),
-      total: count,
-      next,
-    });
   }
 
   @ApiTags('confidential-assets')
@@ -138,60 +98,6 @@ export class ConfidentialAssetsMiddlewareController {
 
     return new PaginatedResultsModel({
       results: data.map(txHistory => new ConfidentialAssetTransactionModel(txHistory)),
-      total: count,
-      next,
-    });
-  }
-
-  @ApiTags('confidential-accounts', 'confidential-transactions')
-  @ApiOperation({
-    summary: 'Get the transactions associated to a Confidential Account',
-    description:
-      'This endpoint provides a list of transactions associated to a Confidential Account',
-  })
-  @ApiParam({
-    name: 'confidentialAccount',
-    description: 'The public key of the Confidential Account',
-    type: 'string',
-    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
-  })
-  @ApiQuery({
-    name: 'direction',
-    description: 'The direction of the transactions with respect to the given Confidential Account',
-    type: 'string',
-    enum: ConfidentialTransactionDirectionEnum,
-    example: ConfidentialTransactionDirectionEnum.All,
-  })
-  @ApiQuery({
-    name: 'size',
-    description: 'The number of transactions to be fetched',
-    type: 'string',
-    required: false,
-    example: '10',
-  })
-  @ApiQuery({
-    name: 'start',
-    description: 'Start key from which transactions are to be fetched',
-    type: 'string',
-    required: false,
-  })
-  @ApiNotFoundResponse({
-    description: 'The confidential account was not found',
-  })
-  @Get('confidential-accounts/:confidentialAccount/associated-transactions')
-  async getAssociatedTransactions(
-    @Param() { confidentialAccount }: ConfidentialAccountParamsDto,
-    @Query() { size, start, direction }: ConfidentialAccountTransactionsDto
-  ): Promise<PaginatedResultsModel<ConfidentialTransaction>> {
-    const { data, count, next } = await this.confidentialAccountsService.getAssociatedTransactions(
-      confidentialAccount,
-      direction,
-      size,
-      new BigNumber(start || 0)
-    );
-
-    return new PaginatedResultsModel({
-      results: data,
       total: count,
       next,
     });

--- a/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.ts
+++ b/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.ts
@@ -12,7 +12,6 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
 import { EventIdentifierModel } from '~/common/models/event-identifier.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
-import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { ConfidentialAssetIdParamsDto } from '~/confidential-assets/dto/confidential-asset-id-params.dto';
 import { ConfidentialAssetTransactionModel } from '~/confidential-assets/models/confidential-asset-transaction.model';
@@ -20,10 +19,7 @@ import { ConfidentialAssetTransactionModel } from '~/confidential-assets/models/
 @ApiTags('confidential-assets')
 @Controller()
 export class ConfidentialAssetsMiddlewareController {
-  constructor(
-    private readonly confidentialAssetsService: ConfidentialAssetsService,
-    private readonly confidentialAccountsService: ConfidentialAccountsService
-  ) {}
+  constructor(private readonly confidentialAssetsService: ConfidentialAssetsService) {}
 
   @ApiOperation({
     summary: 'Get creation event data for a Confidential Asset',

--- a/src/middleware/confidential-transactions-middleware/confidential-transactions-middleware.controller.spec.ts
+++ b/src/middleware/confidential-transactions-middleware/confidential-transactions-middleware.controller.spec.ts
@@ -1,0 +1,59 @@
+import { DeepMocked } from '@golevelup/ts-jest';
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { EventIdentifierModel } from '~/common/models/event-identifier.model';
+import { ConfidentialTransactionsService } from '~/confidential-transactions/confidential-transactions.service';
+import { ConfidentialTransactionsMiddlewareController } from '~/middleware/confidential-transactions-middleware/confidential-transactions-middleware.controller';
+import { mockConfidentialTransactionsServiceProvider } from '~/test-utils/service-mocks';
+
+describe('ConfidentialTransactionsMiddlewareController', () => {
+  let controller: ConfidentialTransactionsMiddlewareController;
+  let mockConfidentialTransactionsService: DeepMocked<ConfidentialTransactionsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfidentialTransactionsMiddlewareController],
+      providers: [mockConfidentialTransactionsServiceProvider],
+    }).compile();
+
+    mockConfidentialTransactionsService = module.get<typeof mockConfidentialTransactionsService>(
+      ConfidentialTransactionsService
+    );
+
+    controller = module.get<ConfidentialTransactionsMiddlewareController>(
+      ConfidentialTransactionsMiddlewareController
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createdAt', () => {
+    it('should throw AppNotFoundError if the event details are not yet ready', () => {
+      mockConfidentialTransactionsService.createdAt.mockResolvedValue(null);
+
+      return expect(() => controller.createdAt({ id: new BigNumber(99) })).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+    });
+
+    describe('otherwise', () => {
+      it('should return the Portfolio creation event details', async () => {
+        const eventIdentifier = {
+          blockDate: new Date('2021-06-26T01:47:45.000Z'),
+          blockNumber: new BigNumber('2719172'),
+          eventIndex: new BigNumber(1),
+          blockHash: 'someHash',
+        };
+        mockConfidentialTransactionsService.createdAt.mockResolvedValue(eventIdentifier);
+
+        const result = await controller.createdAt({ id: new BigNumber(10) });
+
+        expect(result).toEqual(new EventIdentifierModel(eventIdentifier));
+      });
+    });
+  });
+});

--- a/src/middleware/confidential-transactions-middleware/confidential-transactions-middleware.controller.ts
+++ b/src/middleware/confidential-transactions-middleware/confidential-transactions-middleware.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { IdParamsDto } from '~/common/dto/id-params.dto';
+import { EventIdentifierModel } from '~/common/models/event-identifier.model';
+import { ConfidentialTransactionsService } from '~/confidential-transactions/confidential-transactions.service';
+
+@ApiTags('confidential-transactions')
+@Controller()
+export class ConfidentialTransactionsMiddlewareController {
+  constructor(private readonly confidentialTransactionsService: ConfidentialTransactionsService) {}
+
+  @ApiOperation({
+    summary: 'Get creation event data for a Confidential Transaction',
+    description:
+      'The endpoint retrieves the identifier data (block number, date and event index) of the event that was emitted when the given Confidential Transaction was created',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the Confidential Transaction',
+    type: 'string',
+    example: '10',
+  })
+  @ApiOkResponse({
+    description: 'Details of event where the Confidential Transaction was created',
+    type: EventIdentifierModel,
+  })
+  @ApiNotFoundResponse({
+    description: 'Data is not yet processed by the middleware',
+  })
+  @Get('confidential-transactions/:id/created-at')
+  public async createdAt(@Param() { id }: IdParamsDto): Promise<EventIdentifierModel> {
+    const result = await this.confidentialTransactionsService.createdAt(id);
+
+    if (!result) {
+      throw new NotFoundException(
+        "Confidential Transaction's data hasn't yet been processed by the middleware"
+      );
+    }
+
+    return new EventIdentifierModel(result);
+  }
+}

--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -4,9 +4,17 @@ import { DynamicModule, forwardRef, Module } from '@nestjs/common';
 
 import { ConfidentialAccountsModule } from '~/confidential-accounts/confidential-accounts.module';
 import { ConfidentialAssetsModule } from '~/confidential-assets/confidential-assets.module';
+import { ConfidentialTransactionsModule } from '~/confidential-transactions/confidential-transactions.module';
+import { ConfidentialAccountsMiddlewareController } from '~/middleware/confidential-accounts-middleware/confidential-accounts-middleware.controller';
 import { ConfidentialAssetsMiddlewareController } from '~/middleware/confidential-assets-middleware/confidential-assets-middleware.controller';
+import { ConfidentialTransactionsMiddlewareController } from '~/middleware/confidential-transactions-middleware/confidential-transactions-middleware.controller';
 
-@Module({})
+@Module({
+  controllers: [
+    ConfidentialAccountsMiddlewareController,
+    ConfidentialTransactionsMiddlewareController,
+  ],
+})
 export class MiddlewareModule {
   static register(): DynamicModule {
     const controllers = [];
@@ -15,6 +23,8 @@ export class MiddlewareModule {
 
     if (middlewareUrl.length) {
       controllers.push(ConfidentialAssetsMiddlewareController);
+      controllers.push(ConfidentialAccountsMiddlewareController);
+      controllers.push(ConfidentialTransactionsMiddlewareController);
     }
 
     return {
@@ -22,6 +32,7 @@ export class MiddlewareModule {
       imports: [
         forwardRef(() => ConfidentialAssetsModule),
         forwardRef(() => ConfidentialAccountsModule),
+        forwardRef(() => ConfidentialTransactionsModule),
       ],
       controllers,
       providers: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,10 +1990,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.2.0"
 
-"@polymeshassociation/polymesh-private-sdk@1.0.0-alpha.11":
-  version "1.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-private-sdk/-/polymesh-private-sdk-1.0.0-alpha.11.tgz#bac9de5933c91fa4813ec4ec742c372526f1fd4c"
-  integrity sha512-0bn1TGgqnd+38nyee5gFolLhL/AWak4YfXGVBbC1oLRyUUhVeOBH6Y1MrVOqMlV11oOzWW/M8tn7KnMdGxpUIQ==
+"@polymeshassociation/polymesh-private-sdk@1.0.0-alpha.12":
+  version "1.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-private-sdk/-/polymesh-private-sdk-1.0.0-alpha.12.tgz#dfb4053752c6f3961bb815017e34e5f356fb83af"
+  integrity sha512-IIP40lu6pGklekoen2KoimFs9euKzR61m+r7XcTAqk8hh6wqM9x3GyRZqfvtGdPgF8uz9gRs52e3tqtiVc7pIw==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "10.9.1"


### PR DESCRIPTION

### JIRA Link 

DA-1119

### Changelog / Description 

Adds endpoint to get event details when a confidential transaction was created. Also, fixes the `createdAt` value received on fetching confidential transaction details.

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
