### PR TITLE
feat: 🎸 return object instead of string from balance endpoints

### DIFF
--- a/.github/workflows/authenticate-commits.yml
+++ b/.github/workflows/authenticate-commits.yml
@@ -16,7 +16,7 @@ jobs:
           ALLOWED_SIGNERS: ${{ vars.MIDDLEWARE_ALLOWED_SIGNERS }}
         run: |
           mkdir -p ~/.ssh
-          echo $ALLOWED_SIGNERS > ~/.ssh/allowed_signers
+          echo "$ALLOWED_SIGNERS" > ~/.ssh/allowed_signers
           git config --global gpg.ssh.allowedSignersFile "~/.ssh/allowed_signers"
 
       - name: Validate commit signatures

--- a/src/confidential-accounts/confidential-accounts.controller.spec.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.spec.ts
@@ -99,23 +99,29 @@ describe('ConfidentialAccountsController', () => {
     it('should get all confidential asset balances', async () => {
       const confidentialAssetId = 'SOME_ASSET_ID';
       const balance = '0xsomebalance';
-      mockConfidentialAccountsService.getAssetBalance.mockResolvedValue(balance);
+      mockConfidentialAccountsService.getAssetBalance.mockResolvedValue({
+        confidentialAsset: confidentialAssetId,
+        balance,
+      });
 
       let result = await controller.getConfidentialAssetBalance({
         confidentialAccount,
         confidentialAssetId,
       });
 
-      expect(result).toEqual(balance);
+      expect(result).toEqual({ balance, confidentialAsset: confidentialAssetId });
 
-      mockConfidentialAccountsService.getIncomingAssetBalance.mockResolvedValue(balance);
+      mockConfidentialAccountsService.getIncomingAssetBalance.mockResolvedValue({
+        balance,
+        confidentialAsset: confidentialAssetId,
+      });
 
       result = await controller.getIncomingConfidentialAssetBalance({
         confidentialAccount,
         confidentialAssetId,
       });
 
-      expect(result).toEqual(balance);
+      expect(result).toEqual({ balance, confidentialAsset: confidentialAssetId });
     });
   });
 

--- a/src/confidential-accounts/confidential-accounts.controller.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.ts
@@ -122,7 +122,7 @@ export class ConfidentialAccountsController {
   }
 
   @ApiOperation({
-    summary: 'Get balance of a specific Confidential Asset',
+    summary: 'Get the balance of a specific Confidential Asset',
     description:
       'This endpoint retrieves the existing balance of a specific Confidential Asset in the given Confidential Account',
   })
@@ -139,11 +139,11 @@ export class ConfidentialAccountsController {
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
   })
   @ApiOkResponse({
-    description: 'Encrypted balance of the Confidential Asset',
-    type: 'string',
+    description: 'The encrypted balance of the Confidential Asset',
+    type: ConfidentialAssetBalanceModel,
   })
   @ApiNotFoundResponse({
-    description: 'No balance is found for the given Confidential Asset',
+    description: 'No balance was found for the given Confidential Asset',
   })
   @Get(':confidentialAccount/balances/:confidentialAssetId')
   public async getConfidentialAssetBalance(
@@ -152,7 +152,7 @@ export class ConfidentialAccountsController {
       confidentialAccount,
       confidentialAssetId,
     }: ConfidentialAccountParamsDto & ConfidentialAssetIdParamsDto
-  ): Promise<string> {
+  ): Promise<ConfidentialAssetBalanceModel> {
     return this.confidentialAccountsService.getAssetBalance(
       confidentialAccount,
       confidentialAssetId
@@ -208,7 +208,7 @@ export class ConfidentialAccountsController {
   })
   @ApiOkResponse({
     description: 'Encrypted incoming balance of the Confidential Asset',
-    type: 'string',
+    type: ConfidentialAssetBalanceModel,
   })
   @ApiNotFoundResponse({
     description: 'No incoming balance is found for the given Confidential Asset',
@@ -220,7 +220,7 @@ export class ConfidentialAccountsController {
       confidentialAccount,
       confidentialAssetId,
     }: ConfidentialAccountParamsDto & ConfidentialAssetIdParamsDto
-  ): Promise<string> {
+  ): Promise<ConfidentialAssetBalanceModel> {
     return this.confidentialAccountsService.getIncomingAssetBalance(
       confidentialAccount,
       confidentialAssetId

--- a/src/confidential-accounts/confidential-accounts.service.spec.ts
+++ b/src/confidential-accounts/confidential-accounts.service.spec.ts
@@ -195,7 +195,7 @@ describe('ConfidentialAccountsService', () => {
 
         const result = await service.getAssetBalance(confidentialAccount, confidentialAssetId);
 
-        expect(result).toEqual(balance);
+        expect(result).toEqual({ balance, confidentialAsset: confidentialAssetId });
       });
 
       it('should call handleSdkError and throw an error', async () => {
@@ -222,7 +222,7 @@ describe('ConfidentialAccountsService', () => {
           confidentialAssetId
         );
 
-        expect(result).toEqual(balance);
+        expect(result).toEqual({ balance, confidentialAsset: confidentialAssetId });
       });
 
       it('should call handleSdkError and throw an error', async () => {

--- a/src/confidential-accounts/confidential-accounts.service.ts
+++ b/src/confidential-accounts/confidential-accounts.service.ts
@@ -11,6 +11,7 @@ import {
   ResultSet,
 } from '@polymeshassociation/polymesh-private-sdk/types';
 
+import { ConfidentialAssetBalanceModel } from '~/confidential-accounts/models/confidential-asset-balance.model';
 import { ConfidentialTransactionDirectionEnum } from '~/confidential-transactions/types';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { TransactionBaseDto } from '~/polymesh-rest-api/src/common/dto/transaction-base-dto';
@@ -62,11 +63,19 @@ export class ConfidentialAccountsService {
     return account.getBalances();
   }
 
-  public async getAssetBalance(confidentialAccount: string, asset: string): Promise<string> {
+  public async getAssetBalance(
+    confidentialAccount: string,
+    asset: string
+  ): Promise<ConfidentialAssetBalanceModel> {
     const account = await this.findOne(confidentialAccount);
 
-    return await account.getBalance({ asset }).catch(error => {
+    const balance = await account.getBalance({ asset }).catch(error => {
       throw handleSdkError(error);
+    });
+
+    return new ConfidentialAssetBalanceModel({
+      confidentialAsset: asset,
+      balance,
     });
   }
 
@@ -81,11 +90,16 @@ export class ConfidentialAccountsService {
   public async getIncomingAssetBalance(
     confidentialAccount: string,
     asset: string
-  ): Promise<string> {
+  ): Promise<ConfidentialAssetBalanceModel> {
     const account = await this.findOne(confidentialAccount);
 
-    return await account.getIncomingBalance({ asset }).catch(error => {
+    const balance = await account.getIncomingBalance({ asset }).catch(error => {
       throw handleSdkError(error);
+    });
+
+    return new ConfidentialAssetBalanceModel({
+      balance,
+      confidentialAsset: asset,
     });
   }
 

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -344,7 +344,7 @@ describe('ConfidentialAssetsService', () => {
       const encryptedBalance = '0xencryptedbalance';
       when(mockConfidentialAccountsService.getAssetBalance)
         .calledWith(params.confidentialAccount, id)
-        .mockResolvedValue(encryptedBalance);
+        .mockResolvedValue({ balance: encryptedBalance, confidentialAsset: 'SOME_ASSET_ID' });
 
       const mockProof = 'some_proof';
       when(mockConfidentialProofsService.generateBurnProof)

--- a/src/confidential-assets/confidential-assets.service.ts
+++ b/src/confidential-assets/confidential-assets.service.ts
@@ -127,7 +127,7 @@ export class ConfidentialAssetsService {
 
     const { options, args } = extractTxOptions(params);
 
-    const encryptedBalance = await this.confidentialAccountsService.getAssetBalance(
+    const { balance: encryptedBalance } = await this.confidentialAccountsService.getAssetBalance(
       args.confidentialAccount,
       assetId
     );


### PR DESCRIPTION
### JIRA Link 

✅ Closes: [DA-1248](https://polymesh.atlassian.net/browse/DA-1248)

### Changelog / Description 

return ConfidentialAssetBalanceModel from GET
/:confidentialAccount/incoming-balances/:confidentialAssetId and :confidentialAccount/balances/:confidentialAssetId

BREAKING CHANGE: 🧨 GET /:confidentialAccount/incoming-balances/:confidentialAssetId and GET :confidentialAccount/balances/:confidentialAssetId return an object instead of a plain string

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-1248]: https://polymesh.atlassian.net/browse/DA-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ