### PR TITLE
feat: 🎸 return decrypted amount and balance via proof server

### DIFF
--- a/src/confidential-accounts/models/applied-confidential-asset-balance.model.ts
+++ b/src/confidential-accounts/models/applied-confidential-asset-balance.model.ts
@@ -1,8 +1,10 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-private-sdk';
 
 import { ConfidentialAssetBalanceModel } from '~/confidential-accounts/models/confidential-asset-balance.model';
+import { FromBigNumber } from '~/polymesh-rest-api/src/common/decorators/transformation';
 
 export class AppliedConfidentialAssetBalanceModel extends ConfidentialAssetBalanceModel {
   @ApiProperty({
@@ -12,6 +14,23 @@ export class AppliedConfidentialAssetBalanceModel extends ConfidentialAssetBalan
       '0x289ebc384a263acd5820e03988dd17a3cd49ee57d572f4131e116b6bf4c70a1594447bb5d1e2d9cc62f083d8552dd90ec09b23a519b361e458d7fe1e48882261',
   })
   readonly amount: string;
+
+  @ApiPropertyOptional({
+    description: 'The decrypted amount of confidential asset which was deposited.',
+    type: 'string',
+    example: '100',
+  })
+  @FromBigNumber()
+  readonly decryptedAmount?: BigNumber;
+
+  @ApiPropertyOptional({
+    description:
+      'The decrypted balance for the confidential account after the deposit. Will be set if the proof server contains the key for the public account',
+    type: 'string',
+    example: '1000',
+  })
+  @FromBigNumber()
+  readonly decryptedBalance?: BigNumber;
 
   constructor(model: AppliedConfidentialAssetBalanceModel) {
     const { amount, ...rest } = model;


### PR DESCRIPTION
### JIRA Link 

[DA-1269](https://polymesh.atlassian.net/browse/DA-1269)

### Changelog / Description 

return decrypted amounts for /incoming-balances/apply endpoint when the public key is present in the proof server

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-1269]: https://polymesh.atlassian.net/browse/DA-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ